### PR TITLE
Metrowerks CATS: Fix CATSInfoSection misreading offsets

### DIFF
--- a/cs/Rileysoft.DotHack/Rileysoft.DotHack.Tests/Metrowerks/CATS/CATSInfoSectionTests.cs
+++ b/cs/Rileysoft.DotHack/Rileysoft.DotHack.Tests/Metrowerks/CATS/CATSInfoSectionTests.cs
@@ -1,4 +1,5 @@
 ﻿using Rileysoft.DotHack.Metrowerks.CATS;
+using System.Collections.ObjectModel;
 
 namespace Rileysoft.DotHack.Tests.Metrowerks.CATS
 {
@@ -8,19 +9,23 @@ namespace Rileysoft.DotHack.Tests.Metrowerks.CATS
         [DataTestMethod]
         [DataRow(
             new byte[] { 0x02, 0x00, 0x3C, 0x00, 0xD0, 0x00, 0x10, 0x00 },
-            (byte)2, false, (ushort)0x3C, 0x001000d0, -1,
+            (byte)2, (byte)0, (ushort)0x3C, 0x001000d0, new int[] { },
             DisplayName = "Normal Exit")]
         [DataRow(
             new byte[] { 0x02, 0x01, 0x14, 0x00, 0x80, 0x0B, 0x10, 0x00, 0x0C, 0x00, 0x00, 0x00 },
-            (byte)2, true, (ushort)0x14, 0x00100b80, 0x0c,
+            (byte)2, (byte)1, (ushort)0x14, 0x00100b80, new int[] { 0x0c },
             DisplayName = "NSTD Exit")]
+        [DataRow(
+            new byte[] { 0x02, 0x02, 0x14, 0x00, 0x80, 0x0B, 0x10, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x0D, 0x00, 0x00, 0x00 },
+            (byte)2, (byte)2, (ushort)0x14, 0x00100b80, new int[] { 0x0c, 0x0d },
+            DisplayName = "NSTD Exit 2")]
         public void ReadFromStream_Inputs_ReturnsCorrectResult(
             byte[] testData,
             byte SectionType,
-            bool NSTDExit,
+            byte NSTDExit,
             ushort Size,
             int Address,
-            int Offset
+            int[] Offsets
         )
         {
             CATSInfoSection catsInfo = new CATSInfoSection();
@@ -29,11 +34,23 @@ namespace Rileysoft.DotHack.Tests.Metrowerks.CATS
                 catsInfo.ReadFromStream(ms);
             }
 
+            Collection<int> OffsetCollection = new Collection<int>(Offsets);
+
             Assert.AreEqual(SectionType, catsInfo.SectionType);
             Assert.AreEqual(NSTDExit, catsInfo.NSTDExit);
             Assert.AreEqual(Size, catsInfo.Size);
             Assert.AreEqual(Address, catsInfo.Address);
-            Assert.AreEqual(Offset, catsInfo.Offset);
+
+            var ActualOffsets = catsInfo.Offsets;
+            Assert.AreEqual(ActualOffsets.Count, OffsetCollection.Count);
+            for (int i=0; i<ActualOffsets.Count; i++)
+            {
+                int ExpectedOffset = OffsetCollection[i];
+                int ActualOffset = ActualOffsets[i];
+                
+                Assert.AreEqual(ExpectedOffset, ActualOffset, $"Offset {i} was incorrect");
+            }
+
         }
     }
 }

--- a/cs/Rileysoft.DotHack/Rileysoft.DotHack/Metrowerks/CATS/CATSInfoSection.cs
+++ b/cs/Rileysoft.DotHack/Rileysoft.DotHack/Metrowerks/CATS/CATSInfoSection.cs
@@ -1,4 +1,5 @@
 ﻿using Rileysoft.Common.Extensions;
+using System.Collections.ObjectModel;
 
 namespace Rileysoft.DotHack.Metrowerks.CATS
 {
@@ -32,7 +33,7 @@ namespace Rileysoft.DotHack.Metrowerks.CATS
         /// Formally called nstd-exit by Metrowerks CATS.
         /// If set to <see langword="true"/>, the Offset property is read from the stream.
         /// </summary>
-        public bool NSTDExit { get; set; }
+        public byte NSTDExit { get; set; }
 
         /// <summary>
         /// Formally called size by Metrowerks CATS.
@@ -44,19 +45,28 @@ namespace Rileysoft.DotHack.Metrowerks.CATS
         /// </summary>
         public int Address { get; set; }
 
+        private int[] _Offset;
+
         /// <summary>
         /// Formally called offset by Metrowerks CATS.
-        /// Only read if NSTDExit is <see langword="true"/>.
+        /// Returns a new <see cref="Collection{int}"/> created for an array of offsets
+        /// with the same length as <see cref="NSTDExit"/>.
         /// </summary>
-        public int Offset { get; set; }
+        public Collection<int> Offsets
+        {
+            get
+            {
+                return new Collection<int>(_Offset);
+            }
+        }
 
         public CATSInfoSection()
         {
             SectionType = 0;
-            NSTDExit = false;
+            NSTDExit = 0;
             Size = 0;
             Address = 0;
-            Offset = -1;
+            _Offset = Array.Empty<int>();
         }
 
         /// <summary>
@@ -88,13 +98,20 @@ namespace Rileysoft.DotHack.Metrowerks.CATS
             SectionType = byteBuffer[0];
 
             stream.Read(byteBuffer, 0, 1);
-            NSTDExit = byteBuffer[0] != 0;
+            NSTDExit = byteBuffer[0];
 
             Size = stream.ReadUnsignedShortLE();
             Address = stream.ReadIntLE();
 
-            if (NSTDExit)
-                Offset = stream.ReadIntLE();
+            if (NSTDExit == 0)
+                _Offset = Array.Empty<int>(); // Prevents allocation of an empty array.
+            else
+                _Offset = new int[NSTDExit];
+
+            for (int i=0; i<NSTDExit; i++)
+            {
+                _Offset[i] = stream.ReadIntLE();
+            }
         }
     }
 }

--- a/cs/Rileysoft.DotHack/Rileysoft.DotHack/Rileysoft.DotHack.csproj
+++ b/cs/Rileysoft.DotHack/Rileysoft.DotHack/Rileysoft.DotHack.csproj
@@ -13,13 +13,13 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <AnalysisLevel>6.0-all</AnalysisLevel>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
-    <Version>0.2.10-nightly</Version>
+    <Version>0.2.11-nightly</Version>
     <PackageProjectUrl>https://github.com/i-am-Riley/dothack</PackageProjectUrl>
     <Title>Rileysoft.DotHack</Title>
     <Description>Code related to .hack//IMOQ</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>dothack</PackageTags>
-    <PackageReleaseNotes>Added ReadAllFromStream for CATSInfo</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes CATSInfoSection misreading offsets</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
NSTDExit isn't a boolean but rather a byte which tells how many int offsets there are.